### PR TITLE
🚨 Add Missing GitHub Skills Activity (Issue #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Fridays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the missing **GitHub Skills** activity that was announced by the principal but missing from the signup system.

## Changes Made
- ✅ Added "GitHub Skills" activity to the activities database
- ✅ Includes proper description referencing GitHub Certifications program
- ✅ Schedule: Mondays and Fridays, 3:30 PM - 4:30 PM  
- ✅ Max participants: 25 students
- ✅ Ready for immediate student registration

## Fixes
Closes #6 

## Context
This addresses the time-sensitive issue where students were unable to find and sign up for the GitHub Skills activity that was announced in the school assembly. The activity is part of the GitHub Certifications program that will help students with college applications.

## Testing
- [x] Code compiles without syntax errors
- [x] Activity appears in the activities list
- [x] Students can sign up for the new activity

## Screenshots
The new activity will appear in the activities list with:
- **Name**: GitHub Skills
- **Description**: Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications
- **Schedule**: Mondays and Fridays, 3:30 PM - 4:30 PM
- **Capacity**: 25 students